### PR TITLE
refactor: add register-webhook executable

### DIFF
--- a/api/twitter-webhook-listener.ts
+++ b/api/twitter-webhook-listener.ts
@@ -6,21 +6,18 @@ module.exports = async (req: VercelRequest, res: VercelResponse) => {
   const method = req.method.toLowerCase();
   switch (method) {
     case "get": {
-      console.log(req)
       const { crc_token } = req.query;
-      console.log("token: ---------", crc_token)
       if (typeof crc_token === "string" && crc_token.length) {
-        res.status(200).json({
+        return res.status(200).json({
           response_token: getChallengeResponse(crc_token),
         });
       }
-      res
+      return res
         .status(StatusCodes.BAD_REQUEST)
         .send(getReasonPhrase(StatusCodes.BAD_REQUEST));
-      return;
     }
     default:
-      res
+      return res
         .status(StatusCodes.METHOD_NOT_ALLOWED)
         .send(getReasonPhrase(StatusCodes.METHOD_NOT_ALLOWED));
       break;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "cleanup": "rm -rf build",
     "prebuild:prod": "yarn cleanup && yarn sanity-check",
     "build:prod": "tsc --sourceMap false --declaration false -p ./",
-    "dev:twitter-webhook": "vercel dev"
+    "dev:twitter-webhook": "vercel dev",
+    "register-webhook": "NODE_ENV=development ts-node src/bin/register-webhook"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
+    "@types/request": "^2.48.5",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.12.1",

--- a/src/bin/register-webhook.ts
+++ b/src/bin/register-webhook.ts
@@ -1,0 +1,41 @@
+import * as readline from "readline";
+const rl = readline.createInterface(process.stdin, process.stdout);
+import * as util from "util";
+import * as request from "request";
+require("../utils/config");
+
+const post = util.promisify(request.post);
+
+const twitterOAuth = {
+  consumer_key: process.env.TWITTER_CONSUMER_KEY as string,
+  consumer_secret: process.env.TWITTER_CONSUMER_SECRET as string,
+  token: process.env.TWITTER_ACCESS_TOKEN as string,
+  token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET as string,
+};
+
+rl.question(
+  "Your Twitter development environment label: ",
+  function (envLabel: string) {
+    rl.question("Your webhook URL: ", function (webhookUrl: string) {
+      const requestOptions = {
+        url: `https://api.twitter.com/1.1/account_activity/all/${envLabel}/webhooks.json`,
+        oauth: twitterOAuth,
+        headers: {
+          "Content-type": "application/x-www-form-urlencoded",
+        },
+        form: {
+          url: webhookUrl,
+        },
+      };
+      (async (opts) => {
+        try {
+          const body = await post(opts);
+          console.log("result", JSON.stringify(body));
+        } catch (e) {
+          console.error("error: ", JSON.stringify(e));
+        }
+      })(requestOptions);
+      rl.close();
+    });
+  }
+);

--- a/src/bin/register-webhook.ts
+++ b/src/bin/register-webhook.ts
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file run via the `yarn register-webhook`
+ * script.
+ * Running this file activates a CRC check from Twitter for
+ * the validation of a webhook URL for registration
+ */
+
 import * as readline from "readline";
 const rl = readline.createInterface(process.stdin, process.stdout);
 import * as util from "util";

--- a/yarn.lock
+++ b/yarn.lock
@@ -585,6 +585,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/caseless@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
+  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -644,10 +649,25 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
+"@types/request@^2.48.5":
+  version "2.48.5"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.5.tgz#019b8536b402069f6d11bee1b2c03e7f232937a0"
+  integrity sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.0"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/tough-cookie@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
+  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -2117,6 +2137,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
## Description

Include an executable that can be used to register webhooks on the fly via an npm script - `register-webhook`

### Points worth noting

Make sure that the following env variables are set in`.dev.env`
```
- TWITTER_CONSUMER_KEY
- TWITTER_CONSUMER_SECRET
- TWITTER_ACCESS_TOKEN
- TWITTER_ACCESS_TOKEN_SECRET
```
### Type of change

- [x] Refactoring

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings from the linter or any other source
- [x] New and existing unit tests pass locally with my changes