### PR TITLE
refactor: delete webhook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prebuild:prod": "yarn cleanup && yarn sanity-check",
     "build:prod": "tsc --sourceMap false --declaration false -p ./",
     "dev:twitter-webhook": "vercel dev",
-    "register-webhook": "NODE_ENV=development ts-node src/bin/register-webhook"
+    "register-webhook": "NODE_ENV=development ts-node src/bin/register-webhook",
+    "delete-webhook": "NODE_ENV=development ts-node src/bin/delete-webhook"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",

--- a/src/bin/delete-webhook.ts
+++ b/src/bin/delete-webhook.ts
@@ -1,0 +1,42 @@
+/**
+ * The contents of this file run via the `yarn register-webhook`
+ * script.
+ * Running this file activates a CRC check from Twitter for
+ * the validation of a webhook URL for registration
+ */
+
+import * as readline from "readline";
+const rl = readline.createInterface(process.stdin, process.stdout);
+import * as util from "util";
+import * as request from "request";
+require("../utils/config");
+
+const del = util.promisify(request.delete);
+
+const twitterOAuth = {
+  consumer_key: process.env.TWITTER_CONSUMER_KEY as string,
+  consumer_secret: process.env.TWITTER_CONSUMER_SECRET as string,
+  token: process.env.TWITTER_ACCESS_TOKEN as string,
+  token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET as string,
+};
+
+rl.question(
+  "Your Twitter development environment label: ",
+  function (envLabel: string) {
+    rl.question("Your webhook id: ", function (webhookId: string) {
+      const requestOptions = {
+        url: `https://api.twitter.com/1.1/account_activity/all/${envLabel}/webhooks/${webhookId}.json`,
+        oauth: twitterOAuth,
+      };
+      (async (opts) => {
+        try {
+          const body = await del(opts);
+          console.log("result", JSON.stringify(body));
+        } catch (e) {
+          console.error("error: ", JSON.stringify(e));
+        }
+      })(requestOptions);
+      rl.close();
+    });
+  }
+);

--- a/src/bin/delete-webhook.ts
+++ b/src/bin/delete-webhook.ts
@@ -1,8 +1,8 @@
 /**
- * The contents of this file run via the `yarn register-webhook`
- * script.
- * Running this file activates a CRC check from Twitter for
- * the validation of a webhook URL for registration
+ * @fileoverview
+ * The contents of this file can be run via the `yarn delete-webhook`
+ * Running this file deletes a webhook URL from the list of account
+ * activity webhook URLs
  */
 
 import * as readline from "readline";


### PR DESCRIPTION
## Description

Include script for deleting an account activity webhook URL

### Points worth noting

The following env variables must be set in `.dev.env`
```
- TWITTER_CONSUMER_KEY
- TWITTER_CONSUMER_SECRET
- TWITTER_ACCESS_TOKEN as string,
- TWITTER_ACCESS_TOKEN_SECRET
```
### Type of change

- [x] Refactor

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings from the linter or any other source
- [.] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes