### PR TITLE
feat: get engagement count and type

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,3 @@
-<center>[![codecov](https://codecov.io/gh/sudo-kaizen/pick-at-random/branch/main/graph/badge.svg?token=IFBG4890V1)](https://codecov.io/gh/sudo-kaizen/pick-at-random)</center>
+[![codecov](https://codecov.io/gh/sudo-kaizen/pick-at-random/branch/main/graph/badge.svg?token=IFBG4890V1)](https://codecov.io/gh/sudo-kaizen/pick-at-random)
 
 # pick-at-random

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,3 @@
-[![codecov](https://codecov.io/gh/sudo-kaizen/pick-at-random/branch/main/graph/badge.svg?token=IFBG4890V1)](https://codecov.io/gh/sudo-kaizen/pick-at-random)
+<center>[![codecov](https://codecov.io/gh/sudo-kaizen/pick-at-random/branch/main/graph/badge.svg?token=IFBG4890V1)](https://codecov.io/gh/sudo-kaizen/pick-at-random)</center>
 
 # pick-at-random

--- a/api/twitter-webhook-listener.ts
+++ b/api/twitter-webhook-listener.ts
@@ -23,21 +23,21 @@ export default async (
             response_token: getChallengeResponse(crc_token),
           });
         }
+        return res.status(StatusCodes.BAD_REQUEST).send(getReasonPhrase(StatusCodes.BAD_REQUEST));
       } catch (error) {
-        return res.status(StatusCodes.BAD_REQUEST).send("");
+        console.error(error)
+        return res.status(StatusCodes.BAD_REQUEST).send(getReasonPhrase(StatusCodes.BAD_REQUEST));
       }
-      return res.status(StatusCodes.BAD_REQUEST).send("");
     }
 
     case "post": {
       try {
         await handleParActivity(req.body);
-        res.status(StatusCodes.OK).send(null);
+        return res.status(StatusCodes.OK).send(getReasonPhrase(StatusCodes.OK));
       } catch (error) {
         console.error(error);
         return res.status(StatusCodes.BAD_REQUEST).send(error);
       }
-      return res.status(StatusCodes.BAD_REQUEST).send("");
     }
 
     default: {

--- a/api/twitter-webhook-listener.ts
+++ b/api/twitter-webhook-listener.ts
@@ -23,10 +23,11 @@ export default async (
             response_token: getChallengeResponse(crc_token),
           });
         }
-        return res.status(StatusCodes.BAD_REQUEST).send(getReasonPhrase(StatusCodes.BAD_REQUEST));
+        return res
+          .status(StatusCodes.BAD_REQUEST)
+          .send(getReasonPhrase(StatusCodes.BAD_REQUEST));
       } catch (error) {
-        console.error(error)
-        return res.status(StatusCodes.BAD_REQUEST).send(getReasonPhrase(StatusCodes.BAD_REQUEST));
+        return res.status(StatusCodes.BAD_REQUEST).send(error);
       }
     }
 

--- a/src/par-activity/__tests__/handle-tweet-create.spec.ts
+++ b/src/par-activity/__tests__/handle-tweet-create.spec.ts
@@ -11,6 +11,9 @@ import {
   handleTweetCreate,
   getEngagementCount,
   EngagementCountErrorMsg,
+  getEngagementType,
+  EngagementType,
+  EngagementTypeErrorMsg,
 } from "..";
 import { mockRealMention, mockTweet } from "../__mocks__/data";
 
@@ -120,44 +123,67 @@ describe("isPickCommand", () => {
 
 describe("getEngagementCount", () => {
   it("returns the correct engagement count when passed valid arguments", async () => {
-    let count = await getEngagementCount("4 retweets in one hour");
-    expect(count).toBe(4);
-    count = await getEngagementCount("2 retweets tomorrow");
-    expect(count).toBe(2);
-    count = await getEngagementCount("2.5 retweets tomorrow");
-    expect(count).toBe(2);
-    count = await getEngagementCount("10e retweets tomorrow");
-    expect(count).toBe(10);
+    await expect(getEngagementCount("4 retweets in one hour")).resolves.toBe(4);
+    await expect(getEngagementCount("2 retweets tomorrow")).resolves.toBe(2);
+    await expect(getEngagementCount("2.5 retweets tomorrow")).resolves.toBe(2);
+    await expect(getEngagementCount("10e retweets tomorrow")).resolves.toBe(10);
+    expect.assertions(4);
   });
 
   it("throws an error with the proper message when passed invalid arguments", async () => {
     const inputs = [
       {
-        text: "X retweets in one hour",
-        errMsg: EngagementCountErrorMsg.CannotParseToNumber,
+        val: "X retweets in one hour",
+        err: EngagementCountErrorMsg.CannotParse,
       },
       {
-        text: "-1 retweets in one hour",
-        errMsg: EngagementCountErrorMsg.LessThanOne,
+        val: "-1 retweets in one hour",
+        err: EngagementCountErrorMsg.LessThanOne,
       },
       {
-        text: "0 retweets today",
-        errMsg: EngagementCountErrorMsg.LessThanOne,
+        val: "0 retweets today",
+        err: EngagementCountErrorMsg.LessThanOne,
       },
       {
-        text: "e retweets in tomorrow",
-        errMsg: EngagementCountErrorMsg.CannotParseToNumber,
+        val: "e retweets in tomorrow",
+        err: EngagementCountErrorMsg.CannotParse,
       },
     ];
     for (const input of inputs) {
-      await expect(getEngagementCount(input.text)).rejects.toThrow(input.errMsg);
+      await expect(getEngagementCount(input.val)).rejects.toThrow(input.err);
     }
+  });
+});
 
+describe("getEngagementType", () => {
+  it("returns the correct engagement type if it can be handled", async () => {
+    const inputs = [
+      { val: "2 retweets in one hour", type: EngagementType.Retweet },
+      { val: "5 retw in 4 days", type: EngagementType.Retweet },
+      { val: "5 ret in 4 days", type: EngagementType.Retweet },
+      { val: "5 rets in 4 days", type: EngagementType.Retweet },
+      { val: "5 followers in 4 days", type: EngagementType.Follow },
+      { val: "5 follows in 4 days", type: EngagementType.Follow },
+    ];
+    for (const input of inputs) {
+      await expect(getEngagementType(input.val)).resolves.toBe(input.type);
+    }
+  });
+
+  it("throws an error with the correct error message when passed invalid arguments", async () => {
+    const inputs = [
+      { val: "2 in one hour", err: EngagementTypeErrorMsg.CannotParse },
+      { val: "5 likes in 4 days", err: EngagementTypeErrorMsg.CannotHandle },
+      {val: "5 fav in 4 days", err: EngagementTypeErrorMsg.CannotHandle},
+    ];
+    for (const input of inputs) {
+      await expect(getEngagementType(input.val)).rejects.toThrow(input.err);
+    }
   });
 });
 
 describe("handleTweetCreate", () => {
-  it("should respond with when tweets are not real", async () => {
+  it("returns false when tweets are not real", async () => {
     const events: ITweet[] = [
       {
         ...mockTweet,

--- a/src/par-activity/__tests__/handle-tweet-create.spec.ts
+++ b/src/par-activity/__tests__/handle-tweet-create.spec.ts
@@ -9,6 +9,8 @@ import {
   isFeedbackText,
   isPickCommand,
   handleTweetCreate,
+  getEngagementCount,
+  EngagementCountErrorMsg,
 } from "..";
 import { mockRealMention, mockTweet } from "../__mocks__/data";
 
@@ -113,6 +115,44 @@ describe("isPickCommand", () => {
     expect(isPickCommand("3 retweets")).toBe(false);
     expect(isPickCommand("feedback,")).toBe(false);
     expect(isPickCommand("cancel i did not get my picks")).toBe(false);
+  });
+});
+
+describe("getEngagementCount", () => {
+  it("returns the correct engagement count when passed valid arguments", async () => {
+    let count = await getEngagementCount("4 retweets in one hour");
+    expect(count).toBe(4);
+    count = await getEngagementCount("2 retweets tomorrow");
+    expect(count).toBe(2);
+    count = await getEngagementCount("2.5 retweets tomorrow");
+    expect(count).toBe(2);
+    count = await getEngagementCount("10e retweets tomorrow");
+    expect(count).toBe(10);
+  });
+
+  it("throws an error with the proper message when passed invalid arguments", async () => {
+    const inputs = [
+      {
+        text: "X retweets in one hour",
+        errMsg: EngagementCountErrorMsg.CannotParseToNumber,
+      },
+      {
+        text: "-1 retweets in one hour",
+        errMsg: EngagementCountErrorMsg.LessThanOne,
+      },
+      {
+        text: "0 retweets today",
+        errMsg: EngagementCountErrorMsg.LessThanOne,
+      },
+      {
+        text: "e retweets in tomorrow",
+        errMsg: EngagementCountErrorMsg.CannotParseToNumber,
+      },
+    ];
+    for (const input of inputs) {
+      await expect(getEngagementCount(input.text)).rejects.toThrow(input.errMsg);
+    }
+
   });
 });
 

--- a/src/par-activity/__tests__/handle-tweet-create.spec.ts
+++ b/src/par-activity/__tests__/handle-tweet-create.spec.ts
@@ -174,7 +174,7 @@ describe("getEngagementType", () => {
     const inputs = [
       { val: "2 in one hour", err: EngagementTypeErrorMsg.CannotParse },
       { val: "5 likes in 4 days", err: EngagementTypeErrorMsg.CannotHandle },
-      {val: "5 fav in 4 days", err: EngagementTypeErrorMsg.CannotHandle},
+      { val: "5 fav in 4 days", err: EngagementTypeErrorMsg.CannotHandle },
     ];
     for (const input of inputs) {
       await expect(getEngagementType(input.val)).rejects.toThrow(input.err);

--- a/src/par-activity/constants.ts
+++ b/src/par-activity/constants.ts
@@ -6,3 +6,9 @@ export enum CommandType {
 export enum TwitterEndpoint {
   StatusUpdate = "statuses/update",
 }
+
+export enum EngagementCountErrorMsg {
+  LessThanOne = "Nice trick, but no one can randomly pick any number of engagements less than 1 😉",
+  CannotParseToNumber = `😟 I wasn't able to find the number of engagements you want.
+  Could you try again with the format '@PickAtRandom N ..'? N being the number of engagements.`,
+}

--- a/src/par-activity/constants.ts
+++ b/src/par-activity/constants.ts
@@ -9,6 +9,17 @@ export enum TwitterEndpoint {
 
 export enum EngagementCountErrorMsg {
   LessThanOne = "Nice trick, but no one can randomly pick any number of engagements less than 1 😉",
-  CannotParseToNumber = `😟 I wasn't able to find the number of engagements you want.
+  CannotParse = `😟 I wasn't able to find the number of engagements you want.
   Could you try again with the format '@PickAtRandom N ..'? N being the number of engagements.`,
+}
+
+export enum EngagementType {
+  Retweet = "retweet",
+  Follow = "follow",
+}
+
+export enum EngagementTypeErrorMsg {
+  CannotParse = `Uh oh 😟! I couldn't decipher the engagement type you provided.
+  Could you try again with any of 'retweets'/'followers'`,
+  CannotHandle = `Uh oh 😟! I cannot handle picks for that engagement type for now. Can you try again with 'retweets'/'follows'?`,
 }

--- a/src/par-activity/handle-tweet-create.ts
+++ b/src/par-activity/handle-tweet-create.ts
@@ -1,5 +1,9 @@
 import { IRealMentionTweet, ITweet, CommandType, parTwitterClient } from ".";
-import { EngagementCountErrorMsg } from "./constants";
+import {
+  EngagementCountErrorMsg,
+  EngagementType,
+  EngagementTypeErrorMsg,
+} from "./constants";
 
 /**
  * Validates if a mention tweet is a quoted reply and also
@@ -106,17 +110,50 @@ export const handleFeedbackMention = async ({
   return await parTwitterClient.replyMention(id, message, authorName);
 };
 
-export const getEngagementCount = async (text: string): Promise<number> => {
+/**
+ * Extracts and returns the engagement count in a command
+ * tweet
+ * @param {string} text - The command text
+ * @returns {Promise<Number>} The engagement count
+ * @throws {Error}
+ */
+export const getEngagementCount = async (text: string): Promise<Number> => {
   return new Promise((resolve, reject) => {
     const [countStr] = text.split(" ");
     const count = parseInt(countStr.trim(), 10);
     if (Number.isNaN(count)) {
-      reject(new Error(EngagementCountErrorMsg.CannotParseToNumber));
+      reject(new Error(EngagementCountErrorMsg.CannotParse));
     }
     if (count < 1) {
       reject(new Error(EngagementCountErrorMsg.LessThanOne));
     }
     resolve(count);
+  });
+};
+
+/**
+ * Extracts and returns the engagement type from a command
+ * tweet
+ * @param {string} text - The command text
+ * @returns {Promise<string>} The engagement count
+ * @throws {Error}
+ */
+export const getEngagementType = async (text: string): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const [_, engagementType] = text.split(" ");
+    if (engagementType.trim().length < 3) {
+      reject(new Error(EngagementTypeErrorMsg.CannotParse));
+    }
+    const sub = engagementType.trim().substring(0, 3);
+    switch (sub) {
+      case "ret":
+        resolve(EngagementType.Retweet);
+      case "fol":
+        resolve(EngagementType.Follow);
+      default:
+        // FIXME: When the algorithm for finding replies is developed, include it
+        reject(new Error(EngagementTypeErrorMsg.CannotHandle));
+    }
   });
 };
 
@@ -153,11 +190,12 @@ export async function handleTweetCreate(events: ITweet[]): Promise<boolean> {
     for (const mention of pickCommandMentions) {
       try {
         /*
-        using promise.all for this cos the design pattern helps catch
+        using Promise.all for this cos the design pattern helps catch
         any of the errors in one place and responds adequately
          */
         const [count] = await Promise.all([
           await getEngagementCount(mention.cmdText as string),
+          await getEngagementType(mention.cmdText as string),
         ]);
       } catch (e) {
         console.error(JSON.stringify(e));

--- a/src/par-activity/handle-tweet-create.ts
+++ b/src/par-activity/handle-tweet-create.ts
@@ -114,10 +114,10 @@ export const handleFeedbackMention = async ({
  * Extracts and returns the engagement count in a command
  * tweet
  * @param {string} text - The command text
- * @returns {Promise<Number>} The engagement count
+ * @returns {Promise<number>} The engagement count
  * @throws {Error}
  */
-export const getEngagementCount = async (text: string): Promise<Number> => {
+export const getEngagementCount = async (text: string): Promise<number> => {
   return new Promise((resolve, reject) => {
     const [countStr] = text.split(" ");
     const count = parseInt(countStr.trim(), 10);
@@ -148,8 +148,10 @@ export const getEngagementType = async (text: string): Promise<string> => {
     switch (sub) {
       case "ret":
         resolve(EngagementType.Retweet);
+        break;
       case "fol":
         resolve(EngagementType.Follow);
+        break;
       default:
         // FIXME: When the algorithm for finding replies is developed, include it
         reject(new Error(EngagementTypeErrorMsg.CannotHandle));


### PR DESCRIPTION
## Description

Changes in this PR allow the extraction and parsing of the engagement count and type from the command text

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How has this been tested?

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes