### PR TITLE
fix: Jest tests not exiting on CI

### DIFF
--- a/.github/workflows/codecov-actions.yml
+++ b/.github/workflows/codecov-actions.yml
@@ -18,12 +18,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14"
-      - uses: supercharge/redis-github-action@1.2.0
-        with:
-          redis-version: ${{ matrix.redis-version }}
+      - name: Install redis
+        run: sudo apt-get install -y redis-tools redis-server
       - run: node -v
       - run: yarn -v
-      # - run: redis-cli ping
+      - name: Verify that redis is up
+        run: redis-cli ping
       - run: yarn install
-      - run: yarn test:codecov --forceExit
+      - run: yarn test:codecov
       - run: bash <(curl -s https://codecov.io/bash) # Upload to Codecov

--- a/.github/workflows/sanity-check-actions.yml
+++ b/.github/workflows/sanity-check-actions.yml
@@ -35,14 +35,14 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14"
-      - uses: shogo82148/actions-setup-redis@v1
-        with:
-          redis-version: "6.x"
-      - run: redis-cli ping
+      - name: Install redis
+        run: sudo apt-get install -y redis-tools redis-server
       - run: node -v
       - run: yarn -v
+      - name: Verify that redis is up
+        run: redis-cli ping
       - run: yarn install
-      - run: yarn test --forceExit
+      - run: yarn test
   build:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
+    "@types/redis-mock": "^0.17.0",
     "@types/request": "^2.48.5",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
@@ -38,6 +39,7 @@
     "node-mocks-http": "^1.10.1",
     "nodemon": "^2.0.7",
     "prettier": "^2.2.1",
+    "redis-mock": "^0.56.3",
     "ts-jest": "^26.5.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3",

--- a/src/par-activity/cache.ts
+++ b/src/par-activity/cache.ts
@@ -1,10 +1,11 @@
 import { createNodeRedisClient } from "handy-redis";
+import { createClient } from "redis-mock";
 
 const cache =
   process.env.NODE_ENV === "production"
     ? createNodeRedisClient({
         url: process.env.REDIS_URL,
       })
-    : createNodeRedisClient({ host: "127.0.0.1", port: 6379 });
+    : createClient();
 
 export { cache };

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,7 +649,14 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
-"@types/redis@^2.8.27":
+"@types/redis-mock@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@types/redis-mock/-/redis-mock-0.17.0.tgz#13c56c8cf3f748ae1656efc2da9bd6a97cc38e4d"
+  integrity sha512-UDKHu9otOSE1fPjgn0H7UoggqVyuRYfo3WJpdXdVmzgGmr1XIM/dTk/gRYf/bLjIK5mxpV8inA5uNBS2sVOilA==
+  dependencies:
+    "@types/redis" "*"
+
+"@types/redis@*", "@types/redis@^2.8.27":
   version "2.8.28"
   resolved "https://registry.yarnpkg.com/@types/redis/-/redis-2.8.28.tgz#5862b2b64aa7f7cbc76dafd7e6f06992b52c55e3"
   integrity sha512-8l2gr2OQ969ypa7hFOeKqtFoY70XkHxISV0pAwmQ2nm6CSPb1brmTmqJCGGrekCo+pAZyWlNXr+Kvo6L/1wijA==
@@ -4256,6 +4263,11 @@ redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
   integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-mock@^0.56.3:
+  version "0.56.3"
+  resolved "https://registry.yarnpkg.com/redis-mock/-/redis-mock-0.56.3.tgz#e96471bcc774ddc514c2fc49cdd03cab2baecd89"
+  integrity sha512-ynaJhqk0Qf3Qajnwvy4aOjS4Mdf9IBkELWtjd+NYhpiqu4QCNq6Vf3Q7c++XRPGiKiwRj9HWr0crcwy7EiPjYQ==
 
 redis-parser@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description

Fixes #39 

### Points worth noting

Use `redis-mock` for test env

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Jest runs locally without the warning error

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes